### PR TITLE
 Have iter_from/iter_dup_from return a Result

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -424,7 +424,8 @@ mod test {
 
         let items: Vec<(&[u8], &[u8])> = vec!((b"key1", b"val1"),
                                               (b"key2", b"val2"),
-                                              (b"key3", b"val3"));
+                                              (b"key3", b"val3"),
+                                              (b"key5", b"val5"));
 
         {
             let mut txn = env.begin_rw_txn().unwrap();
@@ -447,7 +448,10 @@ mod test {
         assert_eq!(items.clone().into_iter().skip(1).collect::<Vec<_>>(),
                    cursor.iter_from(b"key2").unwrap().collect::<Vec<_>>());
 
-        assert!(cursor.iter_from(b"foo").is_err());
+        assert_eq!(items.clone().into_iter().skip(3).collect::<Vec<_>>(),
+                   cursor.iter_from(b"key4").unwrap().collect::<Vec<_>>());
+
+        assert!(cursor.iter_from(b"key6").is_err());
     }
 
     #[test]
@@ -464,7 +468,10 @@ mod test {
                                               (b"b", b"3"),
                                               (b"c", b"1"),
                                               (b"c", b"2"),
-                                              (b"c", b"3"));
+                                              (b"c", b"3"),
+                                              (b"e", b"1"),
+                                              (b"e", b"2"),
+                                              (b"e", b"3"));
 
         {
             let mut txn = env.begin_rw_txn().unwrap();
@@ -490,6 +497,9 @@ mod test {
 
         assert_eq!(items.clone().into_iter().skip(3).collect::<Vec<(&[u8], &[u8])>>(),
                    cursor.iter_dup_from(b"ab").unwrap().flat_map(|x| x).collect::<Vec<_>>());
+
+        assert_eq!(items.clone().into_iter().skip(9).collect::<Vec<(&[u8], &[u8])>>(),
+                   cursor.iter_dup_from(b"d").unwrap().flat_map(|x| x).collect::<Vec<_>>());
 
         assert_eq!(items.clone().into_iter().skip(3).take(3).collect::<Vec<(&[u8], &[u8])>>(),
                    cursor.iter_dup_of(b"b").unwrap().collect::<Vec<_>>());

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -420,6 +420,8 @@ mod test {
 
         assert_eq!(items.clone().into_iter().skip(1).collect::<Vec<_>>(),
                    cursor.iter_from(b"key2").unwrap().collect::<Vec<_>>());
+
+        assert!(cursor.iter_from(b"foo").is_err());
     }
 
     #[test]
@@ -466,6 +468,7 @@ mod test {
         assert_eq!(items.clone().into_iter().skip(3).take(3).collect::<Vec<(&[u8], &[u8])>>(),
                    cursor.iter_dup_of(b"b").unwrap().collect::<Vec<_>>());
 
+        assert!(cursor.iter_dup_from(b"foo").is_err());
         assert!(cursor.iter_dup_of(b"foo").is_err());
     }
 


### PR DESCRIPTION
(This issue is a clone of https://github.com/danburkert/lmdb-rs/pull/29.)

The _iter_from_ test in https://github.com/danburkert/lmdb-rs/pull/7 is failing because [MDB_SET_RANGE](http://www.lmdb.tech/doc/group__mdb.html#gga1206b2af8b95e7f6b0ef6b28708c9127af9feb0557c2954dbf7732eee5e1b59e7) sets the "Position at first key greater than or equal to specified key." And `foo` is less than `key1`, the first key in the test store; so `cursor.iter_from(b"foo")` sets the cursor position to the first key and returns _Ok_ instead of _Err(NotFound)_.

(The _iter_dup_from_ test doesn't fail in the same way because `foo` is greater than `c`, the greatest key in that test's store.)

This branch fixes the test by seeking to `key6`, which is greater than any key in the store, instead of `foo`. It also adds tests to confirm that seeking to an intermediate key that doesn't exist (`key4` in a store with `key3` and `key5` keys) will move the cursor's position to the next key greater than or equal to that key.

NB: given LMDB's behavior when seeking to a nonexistent but intermediate key (which is actually quite useful for my use case), it isn't clear to me that an _Err(NotFound)_ is the most ergonomic result of seeking to a nonexistent key that is greater than any in the store.

Returning an iterator over an empty set in that case would make the behavior more consistent, and it would be more usable for callers whose behavior doesn't depend on the presence of the given key (nor any greater ones).

Nevertheless, I haven't made that change in this branch. I'll request a pull with it on another branch for your consideration.
