### PR TITLE
prepare to publish on crates.io as lmdb-rkv package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 
-name = "lmdb"
+name = "lmdb-rkv"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 license = "Apache-2.0"
 
 description = "Idiomatic and safe LMDB wrapper."
-repository = "https://github.com/danburkert/lmdb-rs.git"
+repository = "https://github.com/mozilla/lmdb-rs.git"
 readme = "README.md"
-documentation = "https://docs.rs/lmdb"
+documentation = "https://docs.rs/lmdb-rkv"
 keywords = ["LMDB", "database", "storage-engine", "bindings", "library"]
 categories = ["database"]
 
 [badges]
-travis-ci = { repository = "danburkert/lmdb-rs" }
-appveyor = { repository = "danburkert/lmdb-rs" }
+travis-ci = { repository = "mozilla/lmdb-rs" }
+appveyor = { repository = "mozilla/lmdb-rs" }
 
 [workspace]
 members = [
@@ -25,7 +25,7 @@ members = [
 [dependencies]
 bitflags = "1"
 libc = "0.2"
-lmdb-sys = { version = "0.8.0", path = "lmdb-sys" }
+lmdb-sys = "0.8.0"
 
 [dev-dependencies]
 rand = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![cfg_attr(test, feature(test))]
 #![deny(missing_docs)]
-#![doc(html_root_url = "https://docs.rs/lmdb/0.8.0")]
+#![doc(html_root_url = "https://docs.rs/lmdb-rkv/0.8.1")]
 
 extern crate libc;
 extern crate lmdb_sys as ffi;


### PR DESCRIPTION
@ncalexan This branch renames the package in the mozilla/lmdb-rs fork to enable it to be published on crates.io as lmdb-rkv.

I've also incremented the patch number in the version string to reflect the (non-breaking) changes we've landed in the fork. And I replaced the dependency on an internal lmdb-sys with a dependency on the lmdb-sys on crates.io.

(I didn't change the description of the package, but I previously added this statement to the README, which will be reflected in the package listing on crates.io: "This repo is a fork of [danburkert/lmdb-rs](https://github.com/danburkert/lmdb-rs)
with fixes for issues encountered by [mozilla/rkv](https://github.com/mozilla/rkv).")

I know you suggested that I vendor directly from the Git repository. And I've requested https://github.com/alexcrichton/cargo-vendor/pull/92 to fix the cargo-vendor issue that prevents me from doing so. But I'm now leaning toward publishing on crates.io, which is a better-worn cowpath and also unblocks updates to the rkv crate in that repository.

Do you see any significant issues with this approach?
