### PR TITLE
retain crate name for backward-compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ documentation = "https://docs.rs/lmdb-rkv"
 keywords = ["LMDB", "database", "storage-engine", "bindings", "library"]
 categories = ["database"]
 
+[lib]
+name = "lmdb"
+
 [badges]
 travis-ci = { repository = "mozilla/lmdb-rs" }
 appveyor = { repository = "mozilla/lmdb-rs" }


### PR DESCRIPTION
When switching rkv's dependency on lmdb from the lmdb package to lmdb-rkv, I realized that we can avoid requiring source changes in such cases (i.e. `extern crate lmdb; use lmdb::*;` -> `extern crate lmdb_rkv; use lmdb_rkv::*;`) by specifying that the crate name of the lmdb-rkv package remains "lmdb".
