### PR TITLE
fix for #17 - deleting values from an iter_dup db fails

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -80,7 +80,7 @@ pub trait Cursor<'txn> {
 
     /// Iterate over duplicate items in the database starting from the given
     /// key. Each item will be returned as an iterator of its duplicates.
-    fn iter_dup_from<K>(&mut self, key: &K) -> IterDup<'txn> where K: AsRef<[u8]> {
+    fn iter_dup_from<K>(&mut self, key: K) -> IterDup<'txn> where K: AsRef<[u8]> {
         match self.get(Some(key.as_ref()), None, ffi::MDB_SET_RANGE) {
             Ok(_) | Err(Error::NotFound) => (),
             Err(error) => panic!("mdb_cursor_get returned an unexpected error: {}", error),
@@ -89,7 +89,7 @@ pub trait Cursor<'txn> {
     }
 
     /// Iterate over the duplicates of the item in the database with the given key.
-    fn iter_dup_of<K>(&mut self, key: &K) -> Iter<'txn> where K: AsRef<[u8]> {
+    fn iter_dup_of<K>(&mut self, key: K) -> Iter<'txn> where K: AsRef<[u8]> {
         match self.get(Some(key.as_ref()), None, ffi::MDB_SET) {
             Ok(_) | Err(Error::NotFound) => (),
             Err(error) => panic!("mdb_cursor_get returned an unexpected error: {}", error),

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -456,6 +456,7 @@ mod test {
 
         let mut txn = env.begin_rw_txn().unwrap();
         txn.del(db, b"key1", Some(b"val2")).unwrap();
+        txn.del(db, b"key2", None).unwrap();
         txn.commit().unwrap();
 
         let txn = env.begin_rw_txn().unwrap();
@@ -464,6 +465,9 @@ mod test {
             let iter = cur.iter_dup_of(b"key1");
             let vals = iter.map(|(_,x)| x).collect::<Vec<_>>();
             assert_eq!(vals, vec![b"val1", b"val3"]);
+
+            let iter = cur.iter_dup_of(b"key2");
+            assert_eq!(0, iter.count());
         }
         txn.commit().unwrap();
     }


### PR DESCRIPTION
A test for the bug defined in : https://github.com/mozilla/lmdb-rs/issues/17