### PR TITLE
Publish 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "lmdb-rkv"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 license = "Apache-2.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![cfg_attr(test, feature(test))]
 #![deny(missing_docs)]
-#![doc(html_root_url = "https://docs.rs/lmdb-rkv/0.9.0")]
+#![doc(html_root_url = "https://docs.rs/lmdb-rkv/0.9.1")]
 
 extern crate libc;
 extern crate lmdb_sys as ffi;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -425,7 +425,7 @@ mod test {
         txn.del(db, b"key1", None).unwrap();
         assert_eq!(txn.get(db, b"key1"), Err(Error::NotFound));
     }
-    
+
     #[test]
     fn test_put_get_del_multi() {
         let dir = TempDir::new("test").unwrap();
@@ -445,7 +445,7 @@ mod test {
         txn.commit().unwrap();
 
         let txn = env.begin_rw_txn().unwrap();
-        { 
+        {
             let mut cur = txn.open_ro_cursor(db).unwrap();
             let iter = cur.iter_dup_of(b"key1");
             let vals = iter.map(|(_,x)| x).collect::<Vec<_>>();


### PR DESCRIPTION
In preparation for publishing a new version after the fix to RwTransaction.del() in #17. I also removed a bit of trailing whitespace from that fix.