### PR TITLE
update minor version to 0.10.0 for breaking change in #18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "lmdb-rkv"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 license = "Apache-2.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![cfg_attr(test, feature(test))]
 #![deny(missing_docs)]
-#![doc(html_root_url = "https://docs.rs/lmdb-rkv/0.9.1")]
+#![doc(html_root_url = "https://docs.rs/lmdb-rkv/0.10.0")]
 
 extern crate libc;
 extern crate lmdb_sys as ffi;


### PR DESCRIPTION
After publishing 0.9.1 with the fix for #18, I realized that it contains a breaking change to the API: the `Cursor.iter_dup_of()` and `Cursor.iter_dup_from()` methods now take a `K` key argument rather than a `&K` key argument.

So we should rev the minor version rather than just the patch version of the version string.
