### PR TITLE
fix build bustage on obsolete and nightly Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
   - osx
 
 rust:
-- 1.20.0
+- 1.30.0
 - stable
 - nightly
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -448,7 +448,7 @@ mod test {
         {
             let mut cur = txn.open_ro_cursor(db).unwrap();
             let iter = cur.iter_dup_of(b"key1");
-            let vals = iter.map(|(_,x)| x).collect::<Vec<_>>();
+            let vals = iter.filter_map(Result::ok).map(|(_,x)| x).collect::<Vec<_>>();
             assert_eq!(vals, vec![b"val1", b"val2", b"val3"]);
 
         }
@@ -463,7 +463,7 @@ mod test {
         {
             let mut cur = txn.open_ro_cursor(db).unwrap();
             let iter = cur.iter_dup_of(b"key1");
-            let vals = iter.map(|(_,x)| x).collect::<Vec<_>>();
+            let vals = iter.filter_map(Result::ok).map(|(_,x)| x).collect::<Vec<_>>();
             assert_eq!(vals, vec![b"val1", b"val3"]);
 
             let iter = cur.iter_dup_of(b"key2");

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -448,7 +448,7 @@ mod test {
         {
             let mut cur = txn.open_ro_cursor(db).unwrap();
             let iter = cur.iter_dup_of(b"key1");
-            let vals = iter.filter_map(Result::ok).map(|(_,x)| x).collect::<Vec<_>>();
+            let vals = iter.map(|x| x.unwrap()).map(|(_,x)| x).collect::<Vec<_>>();
             assert_eq!(vals, vec![b"val1", b"val2", b"val3"]);
 
         }
@@ -463,7 +463,7 @@ mod test {
         {
             let mut cur = txn.open_ro_cursor(db).unwrap();
             let iter = cur.iter_dup_of(b"key1");
-            let vals = iter.filter_map(Result::ok).map(|(_,x)| x).collect::<Vec<_>>();
+            let vals = iter.map(|x| x.unwrap()).map(|(_,x)| x).collect::<Vec<_>>();
             assert_eq!(vals, vec![b"val1", b"val3"]);
 
             let iter = cur.iter_dup_of(b"key2");


### PR DESCRIPTION
The latest version of cc, version [1.0.27](https://crates.io/crates/cc/1.0.27), requires [str.trim_end_matches()](https://doc.rust-lang.org/nightly/std/primitive.str.html#method.trim_end_matches), which was introduced in Rust 1.30, so this project won't build anymore with Rust 1.20. Thus we should stop building it with that version in automation.
