### PR TITLE
Update LMDB version to latest from master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 [dependencies]
 bitflags = "1"
 libc = "0.2"
-lmdb-sys = "0.8.0"
+lmdb-sys = { path = "lmdb-sys" }
 
 [dev-dependencies]
 rand = "0.4"


### PR DESCRIPTION
Ran into issue on Windows with that the LMDB database files were created up front at the full map_size, instead of incrementally and sparsely. This was fixed in LMDB on master quite a while ago in ITS#8324 and realized this crate was using a 2 year old version of LMDB which I here have updated to the latest available on master.

Unfortunately this fix is not available on the LMDB release branch (`mdb.RE/0.9`) or the recent release from it 0.9.23 two weeks ago. Not fully sure why.

But feel the ITS#8324 fix is critical for many large-scale LMDB database use cases, including our own at Embark, so filing this PR. But would understand if this crate would prefer to be on the the main release line of LMDB instead, but in that case it should at least update to [0.9.23](https://github.com/LMDB/lmdb/commit/2a5eaad6919ce6941dec4f0d5cce370707a00ba7).

Also added a test that verifies if the database map file was created sparsely or not.