### PR TITLE
update LMDB to latest stable release version 0.9.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "lmdb-rkv"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 license = "Apache-2.0"
 

--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 
-name = "lmdb-sys"
+name = "lmdb-rkv-sys"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 license = "Apache-2.0"
 

--- a/lmdb-sys/src/lib.rs
+++ b/lmdb-sys/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types)]
 #![deny(warnings)]
-#![doc(html_root_url = "https://docs.rs/lmdb-sys/0.8.0")]
+#![doc(html_root_url = "https://docs.rs/lmdb-rkv-sys/0.8.1")]
 
 extern crate libc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![cfg_attr(test, feature(test))]
 #![deny(missing_docs)]
-#![doc(html_root_url = "https://docs.rs/lmdb-rkv/0.11.0")]
+#![doc(html_root_url = "https://docs.rs/lmdb-rkv/0.11.1")]
 
 extern crate libc;
 extern crate lmdb_sys as ffi;


### PR DESCRIPTION
This'll also require publishing lmdb-rkv-sys for the first time (until now we've been relying on lmdb-sys from the upstream lmdb-rs project).