### PR TITLE
use newly published lmdb-rkv-sys crate with upgraded LMDB version 0.9.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = [
 [dependencies]
 bitflags = "1"
 libc = "0.2"
-lmdb-sys = "0.8.0"
+lmdb-rkv-sys = "0.8.1"
 
 [dev-dependencies]
 rand = "0.4"

--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -7,9 +7,9 @@ authors = ["Dan Burkert <dan@danburkert.com>"]
 license = "Apache-2.0"
 
 description = "Rust bindings for liblmdb."
-repository = "https://github.com/danburkert/lmdb-rs.git"
+repository = "https://github.com/mozilla/lmdb-rs.git"
 readme = "../README.md"
-documentation = "https://docs.rs/lmdb-sys"
+documentation = "https://docs.rs/lmdb-rkv-sys"
 keywords = ["LMDB", "database", "storage-engine", "bindings", "library"]
 categories = ["database", "external-ffi-bindings"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 #![doc(html_root_url = "https://docs.rs/lmdb-rkv/0.11.1")]
 
 extern crate libc;
-extern crate lmdb_sys as ffi;
+extern crate lmdb_rkv_sys as ffi;
 
 #[cfg(test)] extern crate rand;
 #[cfg(test)] extern crate tempdir;


### PR DESCRIPTION
After #26 landed, I could publish https://crates.io/crates/lmdb-rkv-sys, which then enables us to upgrade lmdb-rkv to use lmdb-rkv-sys and thus actually upgrade lmdb-rkv to LMDB version 0.9.23.

Along the way, I also updated the *repository* and *documentation* fields for the lmdb-rkv-sys crate.