### PR TITLE
undefine HAVE_MEMALIGN before compiling mdb.c

### DIFF
--- a/lmdb-sys/build.rs
+++ b/lmdb-sys/build.rs
@@ -10,6 +10,9 @@ fn main() {
     lmdb.push("libraries");
     lmdb.push("liblmdb");
 
+    let mut undefine_have_memalign_h: PathBuf = PathBuf::from(&env::var("CARGO_MANIFEST_DIR").unwrap());
+    undefine_have_memalign_h.push("undefine-have-memalign.h");
+
     if !pkg_config::find_library("liblmdb").is_ok() {
         let target = env::var("TARGET").expect("No TARGET found");
         let mut build = cc::Build::new();
@@ -21,6 +24,7 @@ fn main() {
             .file(lmdb.join("midl.c"))
             // https://github.com/LMDB/lmdb/blob/LMDB_0.9.21/libraries/liblmdb/Makefile#L25
             .opt_level(2)
+            .flag(&format!("-include{}", undefine_have_memalign_h.to_str().unwrap()))
             .compile("liblmdb.a")
     }
 }

--- a/lmdb-sys/undefine-have-memalign.h
+++ b/lmdb-sys/undefine-have-memalign.h
@@ -1,0 +1,16 @@
+/* Undefine HAVE_MEMALIGN, as mdb.c expects it to be undefined and calls
+ * memalign() without including alloc.h if it's defined in the environment,
+ * even if HAVE_POSIX_MEMALIGN is also defined; and unfortunately some build
+ * environments define HAVE_MEMALIGN even if they HAVE_POSIX_MEMALIGN
+ * (per https://bugzilla.mozilla.org/show_bug.cgi?id=1512541), which triggers
+ * an implicit function declaration and linker bustage on some systems.
+ *
+ * We undefine HAVE_MEMALIGN by including this header file rather than setting
+ * a compiler flag (-UHAVE_MEMALIGN) because the aforementioned build
+ * environment defines it via a header file (mozilla-config.h), which would
+ * override the compiler flag.
+ */
+#ifndef UNDEFINE_HAVE_MEMALIGN_H
+#define UNDEFINE_HAVE_MEMALIGN_H
+#undef HAVE_MEMALIGN
+#endif /* UNDEFINE_HAVE_MEMALIGN_H */


### PR DESCRIPTION
This branch undefines _HAVE_MEMALIGN_, as mdb.c expects it to be undefined and calls `memalign()` without including alloc.h if it's defined in the environment, even if _HAVE_POSIX_MEMALIGN_ is also defined; and unfortunately some build environments define _HAVE_MEMALIGN_ even if they _HAVE_POSIX_MEMALIGN_, which triggers an implicit function declaration and linker bustage on some systems.

We undefine _HAVE_MEMALIGN_ by including a header file rather than a compiler flag (-UHAVE_MEMALIGN) because the aforementioned build environment defines it via a header file (mozilla-config.h), which would override the command-line flag.

@luser Per [this tryserver run](https://treeherder.mozilla.org/#/jobs?repo=try&revision=2f78d415affe5330a9950c387ed3034ef000e5b7), it looks like this change resolves the linker bustage in [bug 1512541](https://bugzilla.mozilla.org/show_bug.cgi?id=1512541). Does it seem like a reasonable workaround, or would you prefer to fix this either upstream (in LMDB proper) or downstream (in Firefox)?
