### PR TITLE
switch to mozilla/lmdb submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lmdb-sys/lmdb"]
 	path = lmdb-sys/lmdb
-	url = https://github.com/LMDB/lmdb
+	url = https://github.com/mozilla/lmdb


### PR DESCRIPTION
In order to apply downstream changes to LMDB itself, we need to maintain our own submodule of that project. So I forked https://github.com/LMDB/lmdb to https://github.com/mozilla/lmdb, and this branch switches the lmdb-sys/lmdb submodule to use that fork.