### PR TITLE
Revert "Fix Android cross-compile build: `cargo build --target armv7-linux-androideabi`"

### DIFF
--- a/lmdb-sys/build.rs
+++ b/lmdb-sys/build.rs
@@ -11,16 +11,11 @@ fn main() {
     lmdb.push("liblmdb");
 
     if !pkg_config::find_library("liblmdb").is_ok() {
-        let target = env::var("TARGET").expect("No TARGET found");
-        let mut build = cc::Build::new();
-        if target.contains("android") {
-            build.define("ANDROID", "1");
-        }
-        build
-            .file(lmdb.join("mdb.c"))
-            .file(lmdb.join("midl.c"))
-            // https://github.com/LMDB/lmdb/blob/LMDB_0.9.21/libraries/liblmdb/Makefile#L25
-            .opt_level(2)
-            .compile("liblmdb.a")
+        cc::Build::new()
+                    .file(lmdb.join("mdb.c"))
+                    .file(lmdb.join("midl.c"))
+                    // https://github.com/LMDB/lmdb/blob/LMDB_0.9.21/libraries/liblmdb/Makefile#L25
+                    .opt_level(2)
+                    .compile("liblmdb.a")
     }
 }


### PR DESCRIPTION
Now that we've backported https://github.com/mozilla/lmdb/commit/0a954f1a67410dceb0fafe202bd6c2f2f409cb4a to the release branch of LMDB that this crate is using (in https://github.com/mozilla/lmdb/commit/4d36c60963e65aa1a753483fd1cfca305a9002cf), it's no longer necessary (and it's ineffectual) to set *ANDROID* in the build.rs script, so this branch reverts the commit that added it (ef250445c192c5fd8630e9b29f2589b467b80e81).
