### PR TITLE
update patch version for lmdb-rkv-sys 0.8.2

### DIFF
--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "lmdb-rkv-sys"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 license = "Apache-2.0"
 

--- a/lmdb-sys/src/lib.rs
+++ b/lmdb-sys/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types)]
 #![deny(warnings)]
-#![doc(html_root_url = "https://docs.rs/lmdb-rkv-sys/0.8.1")]
+#![doc(html_root_url = "https://docs.rs/lmdb-rkv-sys/0.8.2")]
 
 extern crate libc;
 


### PR DESCRIPTION
Update the patch version for lmdb-rkv-sys to 0.8.2 in preparation for publishing lmdb-rkv version 0.11.2.

(We don't yet update lmdb-rkv-sys's dependency entry in lmdb-rkv's Cargo.toml file because the new version of lmdb-rkv-sys has to be published to crates.io before lmdb-rkv can depend on it.)
