### PR TITLE
update patch version for lmdb-rkv 0.11.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "lmdb-rkv"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Dan Burkert <dan@danburkert.com>"]
 license = "Apache-2.0"
 
@@ -28,7 +28,7 @@ members = [
 [dependencies]
 bitflags = "1"
 libc = "0.2"
-lmdb-rkv-sys = "0.8.1"
+lmdb-rkv-sys = "0.8.2"
 
 [dev-dependencies]
 rand = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![cfg_attr(test, feature(test))]
 #![deny(missing_docs)]
-#![doc(html_root_url = "https://docs.rs/lmdb-rkv/0.11.1")]
+#![doc(html_root_url = "https://docs.rs/lmdb-rkv/0.11.2")]
 
 extern crate libc;
 extern crate lmdb_rkv_sys as ffi;


### PR DESCRIPTION
Update the patch version for lmdb-rkv to 0.11.2 and the lmdb-rkv-sys dependency version to 0.8.2 in preparation for publishing lmdb-rkv 0.11.2.