### PR TITLE
exclude CI config files from package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,14 @@ documentation = "https://docs.rs/lmdb-rkv"
 keywords = ["LMDB", "database", "storage-engine", "bindings", "library"]
 categories = ["database"]
 
+exclude = [
+  # Exclude CI config files from package.
+  "/.appveyor.yml",
+  "/.travis.yml",
+  "/azure-pipelines-template.yml",
+  "/azure-pipelines.yml",
+]
+
 [lib]
 name = "lmdb"
 


### PR DESCRIPTION
I noticed when vendoring lmdb-rkv into mozilla-central that its crate includes the CI configuration files, which aren't useful to its consumers and just take up space in the package.

Is there anything else we should exclude, such as _.gitignore_, _.gitmodules_, and _.rustfmt.toml_?
