### PR TITLE
Add freelist to environment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,10 @@ members = [
 
 [dependencies]
 bitflags = "1"
+byteorder = "1.0"
 libc = "0.2"
 lmdb-rkv-sys = "0.8.2"
 
 [dev-dependencies]
 rand = "0.4"
 tempdir = "0.3"
-byteorder = "1.0"

--- a/src/database.rs
+++ b/src/database.rs
@@ -31,6 +31,12 @@ impl Database {
         Ok(Database { dbi: dbi })
     }
 
+    pub(crate) fn freelist_db() -> Database {
+        Database {
+            dbi: 0,
+        }
+    }
+
     /// Returns the underlying LMDB database handle.
     ///
     /// The caller **must** ensure that the handle is not used after the lifetime of the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 
 extern crate libc;
 extern crate lmdb_rkv_sys as ffi;
+extern crate byteorder;
 
 #[cfg(test)] extern crate rand;
 #[cfg(test)] extern crate tempdir;
@@ -67,9 +68,7 @@ mod transaction;
 #[cfg(test)]
 mod test_utils {
 
-    extern crate byteorder;
-
-    use self::byteorder::{ByteOrder, LittleEndian};
+    use byteorder::{ByteOrder, LittleEndian};
     use tempdir::TempDir;
 
     use super::*;


### PR DESCRIPTION
This allows the consumer to query the total # of pages on the freelist for each LMDB environment, then they can use it with `env.info()` to precisely check the space usage of that environment. 

Note: the approach that I used to query the freelist was not documented in LMDB but a direct copy from its utility [mdb_stat](https://github.com/LMDB/lmdb/blob/mdb.master/libraries/liblmdb/mdb_stat.c#L157). I won't feel bad if we decide to not use the uncharted stuff from LMDB. 😉