### PR TITLE
enable configuration of MDB_IDL_LOGN

### DIFF
--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -21,3 +21,25 @@ libc = "0.2"
 [build-dependencies]
 pkg-config = "0.3.2"
 cc = "1"
+
+[features]
+default = []
+
+# These features configure the MDB_IDL_LOGN macro, which determines
+# the size of the free and dirty page lists (and thus the amount of memory
+# allocated when opening an LMDB environment in read-write mode).
+#
+# Each feature defines MDB_IDL_LOGN as the value in the name of the feature.
+# That means these features are mutually exclusive, and you must not specify
+# more than one at the same time (or the crate will fail to compile).
+#
+# For more information on the motivation for these features (and their effect),
+# see https://github.com/mozilla/lmdb/pull/2.
+mdb_idl_logn_8 = []
+mdb_idl_logn_9 = []
+mdb_idl_logn_10 = []
+mdb_idl_logn_11 = []
+mdb_idl_logn_12 = []
+mdb_idl_logn_13 = []
+mdb_idl_logn_14 = []
+mdb_idl_logn_15 = []

--- a/lmdb-sys/build.rs
+++ b/lmdb-sys/build.rs
@@ -4,6 +4,34 @@ extern crate cc;
 use std::env;
 use std::path::PathBuf;
 
+#[cfg(feature = "mdb_idl_logn_8")]
+const MDB_IDL_LOGN: u8 = 8;
+#[cfg(feature = "mdb_idl_logn_9")]
+const MDB_IDL_LOGN: u8 = 9;
+#[cfg(feature = "mdb_idl_logn_10")]
+const MDB_IDL_LOGN: u8 = 10;
+#[cfg(feature = "mdb_idl_logn_11")]
+const MDB_IDL_LOGN: u8 = 11;
+#[cfg(feature = "mdb_idl_logn_12")]
+const MDB_IDL_LOGN: u8 = 12;
+#[cfg(feature = "mdb_idl_logn_13")]
+const MDB_IDL_LOGN: u8 = 13;
+#[cfg(feature = "mdb_idl_logn_14")]
+const MDB_IDL_LOGN: u8 = 14;
+#[cfg(feature = "mdb_idl_logn_15")]
+const MDB_IDL_LOGN: u8 = 15;
+#[cfg(not(any(
+    feature = "mdb_idl_logn_8",
+    feature = "mdb_idl_logn_9",
+    feature = "mdb_idl_logn_10",
+    feature = "mdb_idl_logn_11",
+    feature = "mdb_idl_logn_12",
+    feature = "mdb_idl_logn_13",
+    feature = "mdb_idl_logn_14",
+    feature = "mdb_idl_logn_15",
+)))]
+const MDB_IDL_LOGN: u8 = 16;
+
 fn main() {
     let mut lmdb: PathBuf = PathBuf::from(&env::var("CARGO_MANIFEST_DIR").unwrap());
     lmdb.push("lmdb");
@@ -12,6 +40,7 @@ fn main() {
 
     if !pkg_config::find_library("liblmdb").is_ok() {
         cc::Build::new()
+                    .define("MDB_IDL_LOGN", Some(MDB_IDL_LOGN.to_string().as_str()))
                     .file(lmdb.join("mdb.c"))
                     .file(lmdb.join("midl.c"))
                     // https://github.com/LMDB/lmdb/blob/LMDB_0.9.21/libraries/liblmdb/Makefile#L25


### PR DESCRIPTION
Over in [bug 1543795](https://bugzilla.mozilla.org/show_bug.cgi?id=1543795), @glandium and @alexcrichton suggest using Rust feature flags to configure `MDB_IDL_LOGN`. Since there are a limited number of reasonable values for that macro, this approach is feasible, even though Rust feature flags are simple toggles, so we have to create a unique one for each possible value.

This branch does that for integer values `8`–`15` inclusive, with the default value—if no flag is set—being `16` (the same as the default value in the LMDB source).

These flags should allow Firefox and other consumers to configure `MDB_IDL_LOGN` to best suit their needs and constraints.

Note: we can't simply define `MDB_IDL_LOGN=16` if `#[cfg(feature = "default")]`, since the "default" feature is enabled by, well, default; and specifying another feature would then try to define `MDB_IDL_LOGN` as both `16` and the other value. (Well, we could, if we forced the users of these flags to also specify `default-features = false`; but that complicates usage.)

@ncloudioj Does this seem reasonable?
