### PR TITLE
Fix typo

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -439,8 +439,8 @@ impl EnvironmentBuilder {
     /// Currently a moderate number of slots are cheap but a huge number gets
     /// expensive: 7-120 words per transaction, and every `Transaction::open_db`
     /// does a linear search of the opened slots.
-    pub fn set_max_dbs(&mut self, max_readers: c_uint) -> &mut EnvironmentBuilder {
-        self.max_dbs = Some(max_readers);
+    pub fn set_max_dbs(&mut self, max_dbs: c_uint) -> &mut EnvironmentBuilder {
+        self.max_dbs = Some(max_dbs);
         self
     }
 


### PR DESCRIPTION
When I'm reading [the document on Docs.rs](https://docs.rs/lmdb-rkv/0.11.4/lmdb/struct.EnvironmentBuilder.html#method.set_max_dbs), I find this typo.