### PR TITLE
prioritize testing lmdb-rkv with in-tree lmdb-rkv-sys; document publication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,16 @@ members = [
 bitflags = "1"
 byteorder = "1.0"
 libc = "0.2"
-lmdb-rkv-sys = "0.8.3"
+
+# In order to ensure that we test lmdb-rkv in CI against the in-tree version
+# of lmdb-rkv-sys, we specify the dependency as a path here.
+#
+# But we can't publish the lmdb-rkv crate to crates.io with a path dependency,
+# so we have to temporarily change this to point to the current version
+# of lmdb-rkv-sys on crates.io when publishing lmdb-rkv to that crate registry.
+#
+# (See "Publishing to crates.io" in README.md for more information.)
+lmdb-rkv-sys = { path = "./lmdb-sys" }
 
 [dev-dependencies]
 rand = "0.4"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,33 @@ cd lmdb-rs
 cargo build
 ```
 
+## Publishing to crates.io
+
+To publish the lmdb-rkv-sys crate to crates.io:
+
+```bash
+git clone --recursive git@github.com:mozilla/lmdb-rs.git
+cd lmdb-rs/lmdb-sys
+# Update the version string in lmdb-sys/Cargo.toml and lmdb-sys/src/lib.rs.
+cargo publish
+git tag lmdb-rkv-sys-$VERSION # where $VERSION is the updated version string
+git push git@github.com:mozilla/lmdb-rs.git --tags
+```
+
+To publish the lmdb-rkv crate to crates.io:
+
+```bash
+git clone --recursive git@github.com:mozilla/lmdb-rs.git
+cd lmdb-rs
+# Update the version string in Cargo.toml and src/lib.rs and temporarily change
+# the lmdb-rkv-sys dependency in Cargo.toml to the latest version on crates.io.
+cargo publish
+git tag $VERSION # where $VERSION is the updated version string
+git push git@github.com:mozilla/lmdb-rs.git --tags
+# Change the lmdb-rkv-sys dependency in Cargo.toml back to a path dependency
+# on the ./lmdb-sys directory.
+```
+
 ## Features
 
 * [x] lmdb-sys.


### PR DESCRIPTION
@ncloudioj In order to ensure that we test lmdb-rkv in CI against the in-tree version of lmdb-rkv-sys, we should specify the dependency as a path.

We can't publish the lmdb-rkv crate to crates.io with a path dependency, so we'll have to temporarily change it to point to the current version of lmdb-rkv-sys on crates.io when publishing lmdb-rkv to that crate registry.

But that shouldn't be too cumbersome. And it seems better to optimize the dependency for testing in CI, which happens on every pull request, rather than optimizing for publishing, which only happens occasionally.

Regardless, it occurred to me that it would also be useful to document the process of publishing these crates to crates.io, so I've also added instructions to the README. Let me know how those look (or if you think we should put them somewhere else).
