### PR TITLE
Remove with-clang feature in favor of using $CC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,12 @@ before_script:
 
 script:
   - cargo +nightly-2019-09-11 fmt --all -- --check
-  - cargo +nightly-2019-09-11 clippy --all-features -- -D warnings -A clippy::match-ref-pats -A clippy::needless-lifetimes
-  - cargo build --features with-clang --verbose
-  - cargo build --features with-asan --verbose
-  - cargo build --features with-fuzzer --verbose
-  - cargo build --features with-fuzzer-no-link --verbose
-  - cargo build --features with-asan,with-fuzzer --verbose
-  - cargo build --features with-asan,with-fuzzer-no-link --verbose
+  - CC="clang" cargo +nightly-2019-09-11 clippy --all-features -- -D warnings -A clippy::match-ref-pats -A clippy::needless-lifetimes
+  - CC="clang" cargo build --features with-asan --verbose
+  - CC="clang" cargo build --features with-fuzzer --verbose
+  - CC="clang" cargo build --features with-fuzzer-no-link --verbose
+  - CC="clang" cargo build --features with-asan,with-fuzzer --verbose
+  - CC="clang" cargo build --features with-asan,with-fuzzer-no-link --verbose
   - cargo build --verbose
   - export RUST_BACKTRACE=1
   - cargo test --all --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ rust:
   - beta
   - nightly
 
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true
+
 before_script:
   # We install a known-to-have-rustfmt version of the nightly toolchain
   # in order to run the nightly version of rustfmt, which supports rules

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ tempdir = "0.3"
 
 [features]
 default = []
-with-clang = ["lmdb-rkv-sys/with-clang"]
 with-asan = ["lmdb-rkv-sys/with-asan"]
 with-fuzzer = ["lmdb-rkv-sys/with-fuzzer"]
 with-fuzzer-no-link = ["lmdb-rkv-sys/with-fuzzer-no-link"]

--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -33,10 +33,9 @@ bindgen = "0.51"
 
 [features]
 default = []
-with-clang = []
-with-asan = ["with-clang"]
-with-fuzzer = ["with-clang"]
-with-fuzzer-no-link = ["with-clang"]
+with-asan = []
+with-fuzzer = []
+with-fuzzer-no-link = []
 
 # These features configure the MDB_IDL_LOGN macro, which determines
 # the size of the free and dirty page lists (and thus the amount of memory

--- a/lmdb-sys/build.rs
+++ b/lmdb-sys/build.rs
@@ -61,10 +61,6 @@ fn main() {
             .flag_if_supported("-Wbad-function-cast")
             .flag_if_supported("-Wuninitialized");
 
-        if env::var("CARGO_FEATURE_WITH_CLANG").is_ok() {
-            builder.compiler("clang");
-        }
-
         if env::var("CARGO_FEATURE_WITH_ASAN").is_ok() {
             builder.flag("-fsanitize=address");
         }


### PR DESCRIPTION
Signed-off-by: Victor Porof <victor.porof@gmail.com>

We need this to avoid build failures such as https://treeherder.mozilla.org/#/jobs?repo=try&revision=ea6e31b7bb68c785fc6a61efa79a69fd296d5893