### PR TITLE
Don't use bindgen's default features.

### DIFF
--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lmdb-rkv-sys"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "0.9.3"
+version = "0.9.4"
 authors = ["Dan Burkert <dan@danburkert.com>", "Victor Porof <vporof@mozilla.com>"]
 license = "Apache-2.0"
 description = "Rust bindings for liblmdb."
@@ -29,7 +29,7 @@ libc = "0.2"
 [build-dependencies]
 pkg-config = "0.3"
 cc = "1.0"
-bindgen = "0.51"
+bindgen = { version = "0.51-oldsyn", default-features = false }
 
 [features]
 default = []

--- a/lmdb-sys/src/lib.rs
+++ b/lmdb-sys/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 #![allow(non_camel_case_types)]
 #![allow(clippy::all)]
-#![doc(html_root_url = "https://docs.rs/lmdb-rkv-sys/0.9.3")]
+#![doc(html_root_url = "https://docs.rs/lmdb-rkv-sys/0.9.4")]
 
 extern crate libc;
 


### PR DESCRIPTION
And use old syn until the rest of mozilla-central is updated.

This prevents dependencies like which to be built, which is unnecessary, and
avoids duplicate versions of syn / quote in Gecko, which slow down build times.