### PR TITLE
Make bindgen optional

### DIFF
--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -12,8 +12,7 @@ readme = "../README.md"
 keywords = ["LMDB", "database", "storage-engine", "bindings", "library"]
 categories = ["database", "external-ffi-bindings"]
 
-# NB: When generating bindings, change to "bindgen.rs" or use something
-# like `cargo-script` instead.
+# NB: Use "--feature bindgen" to generate bindings.
 build = "build.rs"
 
 [lib]
@@ -29,7 +28,7 @@ libc = "0.2"
 [build-dependencies]
 pkg-config = "0.3"
 cc = "1.0"
-bindgen = { version = "0.51.1-oldsyn", default-features = false }
+bindgen = { version = "0.51.1-oldsyn", default-features = false, optional = true }
 
 [features]
 default = []

--- a/lmdb-sys/bindgen.rs
+++ b/lmdb-sys/bindgen.rs
@@ -1,5 +1,3 @@
-extern crate bindgen;
-
 use bindgen::callbacks::IntKind;
 use bindgen::callbacks::ParseCallbacks;
 use std::env;
@@ -38,7 +36,7 @@ impl ParseCallbacks for Callbacks {
     }
 }
 
-fn main() {
+pub fn generate() {
     let mut lmdb = PathBuf::from(&env::var("CARGO_MANIFEST_DIR").unwrap());
     lmdb.push("lmdb");
     lmdb.push("libraries");

--- a/lmdb-sys/build.rs
+++ b/lmdb-sys/build.rs
@@ -1,6 +1,13 @@
 extern crate cc;
 extern crate pkg_config;
 
+#[cfg(feature = "bindgen")]
+extern crate bindgen;
+
+#[cfg(feature = "bindgen")]
+#[path = "bindgen.rs"]
+mod generate;
+
 use std::env;
 use std::path::PathBuf;
 
@@ -39,6 +46,9 @@ macro_rules! warn {
 }
 
 fn main() {
+    #[cfg(feature = "bindgen")]
+    generate::generate();
+
     let mut lmdb = PathBuf::from(&env::var("CARGO_MANIFEST_DIR").unwrap());
     lmdb.push("lmdb");
     lmdb.push("libraries");


### PR DESCRIPTION
This PR makes `bindgen` optional, so we don't need to compile unnecessary `bindgen` and avoid `clang-sys` version conflicts in some cases.