### PR TITLE
Don't depend on bindgen if not needed

### DIFF
--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["database", "external-ffi-bindings"]
 
 # NB: When generating bindings, change to "bindgen.rs" or use something
 # like `cargo-script` instead.
+# You must also uncomment the bindgen dependency below.
 build = "build.rs"
 
 [lib]
@@ -29,7 +30,8 @@ libc = "0.2"
 [build-dependencies]
 pkg-config = "0.3"
 cc = "1.0"
-bindgen = { version = "0.51.1-oldsyn", default-features = false }
+# NB: Only necessary when regenerating bindings, see above for `build`
+#bindgen = { version = "0.51.1-oldsyn", default-features = false }
 
 [features]
 default = []


### PR DESCRIPTION
We're using rkv, and thus lmdb-rs, in Glean on Android and iOS.
For us final binary size is a bit of an issue to keep an eye on and one big contender was regex, luckily recently regex got `featur-ized`, meaning we can disable most of its features to reduce size.

However, in Cargo features for dependencies are unified across all dependencies, dev-dependencies, build-dependencies and platform-specific dependencies.

Now, with lmdb-rs (build-)depending on bindgen and bindgen depending on regex, this will pull back in all the default features of regex and thus blow up our binary and there's no way for us to stop this.

Now to this change:
bindgen is only required to regenerate [the bindings](https://github.com/mozilla/lmdb-rs/blob/master/lmdb-sys/src/bindings.rs), but otherwise these are committed to the repository.
It should therefore be fine to not depend on it for a general release.
This will certainly work for all consumers through crates.io
I expect mozilla-central to just be another consumer (vendoring it all in), so I guess even those don't need it.

What do you think?
After this change we should be able to upgrade the version we use (unless any other dependency causes similar issues, but that's on me to trace down and fix then)