### PR TITLE
Add feature to compile lmdb with NDEBUG

### DIFF
--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -35,6 +35,7 @@ default = []
 with-asan = []
 with-fuzzer = []
 with-fuzzer-no-link = []
+with-ndebug = []
 
 # These features configure the MDB_IDL_LOGN macro, which determines
 # the size of the free and dirty page lists (and thus the amount of memory

--- a/lmdb-sys/build.rs
+++ b/lmdb-sys/build.rs
@@ -71,6 +71,11 @@ fn main() {
             .flag_if_supported("-Wbad-function-cast")
             .flag_if_supported("-Wuninitialized");
 
+
+        if env::var("CARGO_FEATURE_WITH_NDEBUG").is_ok() {
+            builder.define("NDEBUG", Some("1"));
+        }
+
         if env::var("CARGO_FEATURE_WITH_ASAN").is_ok() {
             builder.flag("-fsanitize=address");
         }


### PR DESCRIPTION
The `with-ndebug` features sets `NDEBUG` at compile time, which disables `mdb_assert_fail`.
Otherwise this prints directly to `stderr`, causing problems on old Android versions.