### PR TITLE
Support windows FileHandle types

### DIFF
--- a/lmdb-sys/bindgen.rs
+++ b/lmdb-sys/bindgen.rs
@@ -52,6 +52,7 @@ pub fn generate() {
         .whitelist_function("^(MDB|mdb)_.*")
         .ctypes_prefix("::libc")
         .blacklist_item("mode_t")
+        .blacklist_item("filehandle_t")
         .blacklist_item("^__.*")
         .parse_callbacks(Box::new(Callbacks {}))
         .layout_tests(false)

--- a/lmdb-sys/src/bindings.rs
+++ b/lmdb-sys/src/bindings.rs
@@ -53,7 +53,7 @@ pub const MDB_BAD_VALSIZE: ::libc::c_int = -30781;
 pub const MDB_BAD_DBI: ::libc::c_int = -30780;
 pub const MDB_LAST_ERRCODE: ::libc::c_int = -30780;
 pub type mdb_mode_t = mode_t;
-pub type mdb_filehandle_t = ::libc::c_int;
+pub type mdb_filehandle_t = filehandle_t;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct MDB_env {

--- a/lmdb-sys/src/lib.rs
+++ b/lmdb-sys/src/lib.rs
@@ -12,4 +12,11 @@ pub type mode_t = ::libc::mode_t;
 #[allow(non_camel_case_types)]
 pub type mode_t = ::libc::c_int;
 
+#[cfg(unix)]
+#[allow(non_camel_case_types)]
+pub type filehandle_t = ::libc::c_int;
+#[cfg(windows)]
+#[allow(non_camel_case_types)]
+pub type filehandle_t = *mut ::libc::c_void;
+
 include!("bindings.rs");

--- a/lmdb-sys/tests/simple.rs
+++ b/lmdb-sys/tests/simple.rs
@@ -3,6 +3,7 @@ extern crate lmdb_sys;
 use lmdb_sys::*;
 
 use std::ffi::{c_void, CString};
+use std::fs::File;
 use std::ptr;
 
 // https://github.com/victorporof/lmdb/blob/mdb.master/libraries/liblmdb/moz-test.c
@@ -32,6 +33,18 @@ fn test_simple_32() {
 #[cfg(target_pointer_width = "64")]
 fn test_simple_64() {
     test_simple("./tests/fixtures/testdb")
+}
+
+#[cfg(windows)]
+fn get_file_fd(file: &File) -> std::os::windows::io::RawHandle {
+    use std::os::windows::io::AsRawHandle;
+    file.as_raw_handle()
+}
+
+#[cfg(unix)]
+fn get_file_fd(file: &File) -> std::os::unix::io::RawFd {
+    use std::os::unix::io::AsRawFd;
+    file.as_raw_fd()
 }
 
 fn test_simple(env_path: &str) {
@@ -66,6 +79,13 @@ fn test_simple(env_path: &str) {
         E!(mdb_txn_begin(env, ptr::null_mut(), 0, &mut txn));
         E!(mdb_put(txn, dbi, &mut key, &mut data, 0));
         E!(mdb_txn_commit(txn));
+    }
+
+    let file = File::create("./tests/fixtures/copytestdb.mdb").unwrap();
+
+    unsafe {
+        let fd = get_file_fd(&file);
+        E!(mdb_env_copyfd(env, fd));
 
         mdb_dbi_close(env, dbi);
         mdb_env_close(env);


### PR DESCRIPTION
Currently the windows support is not completely full as it didn't correctly support the windows file handles. I changed the type to make it relative to the running platform like for the `mode_t` type.