### PR TITLE
Add feature to make using local system liblmdb optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,14 +45,15 @@ libc = "0.2"
 # of lmdb-rkv-sys on crates.io when publishing lmdb-rkv to that crate registry.
 #
 # (See "Publishing to crates.io" in README.md for more information.)
-lmdb-rkv-sys = { path = "./lmdb-sys" }
+lmdb-rkv-sys = { path = "./lmdb-sys", default-features = false }
 
 [dev-dependencies]
 rand = "0.4"
 tempdir = "0.3"
 
 [features]
-default = []
+default = ["use-local-lib"]
+use-local-lib = ["lmdb-rkv-sys/use-local-lib"] # use local liblmdb if exists, instead of compiling from source
 with-asan = ["lmdb-rkv-sys/with-asan"]
 with-fuzzer = ["lmdb-rkv-sys/with-fuzzer"]
 with-fuzzer-no-link = ["lmdb-rkv-sys/with-fuzzer-no-link"]

--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -26,12 +26,13 @@ appveyor = { repository = "mozilla/lmdb-rs" }
 libc = "0.2"
 
 [build-dependencies]
-pkg-config = "0.3"
 cc = "1.0"
 bindgen = { version = "0.53.2", default-features = false, optional = true, features = ["runtime"] }
+pkg-config = { version = "0.3", optional = true }
 
 [features]
-default = []
+default = ["use-local-lib"]
+use-local-lib = ["pkg-config"] # use local liblmdb if exists, instead of compiling from source
 with-asan = []
 with-fuzzer = []
 with-fuzzer-no-link = []

--- a/lmdb-sys/build.rs
+++ b/lmdb-sys/build.rs
@@ -61,8 +61,10 @@ fn main() {
     }
 
     #[cfg(feature = "use-local-lib")]
-    if pkg_config::find_library("liblmdb").is_ok() {
-        return;
+    {
+        if pkg_config::find_library("liblmdb").is_ok() {
+            return;
+        }
     }
 
     // compile library


### PR DESCRIPTION
This adds a `use-local-lib` feature that makes it possible to disable using local system `libmdb` and always build LMDB from source for users that want to guarantee the exact version of LMDB used.

Made it enabled by default to not change existing behavior, but would prefer it to be something crate users opt into instead.