### PR TITLE
Fix octal mode literal

### DIFF
--- a/lmdb-sys/tests/simple.rs
+++ b/lmdb-sys/tests/simple.rs
@@ -65,7 +65,7 @@ fn test_simple(env_path: &str) {
     unsafe {
         E!(mdb_env_create(&mut env));
         E!(mdb_env_set_maxdbs(env, 2));
-        E!(mdb_env_open(env, str!(env_path), 0, 0664));
+        E!(mdb_env_open(env, str!(env_path), 0, 0o664));
 
         E!(mdb_txn_begin(env, ptr::null_mut(), 0, &mut txn));
         E!(mdb_dbi_open(txn, str!("subdb"), MDB_CREATE, &mut dbi));


### PR DESCRIPTION
`0664` is actually a decimal constant in Rust, and needs to be `0o664` for octal.

A hard habit to break, especially with all the surrounding FFI. Thanks to Clippy for spotting this.