### PR TITLE
Backwards Iterators

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -62,7 +62,7 @@ pub trait Cursor<'txn> {
     }
 
     /// Iterate over database items backwards. The iterator will begin with item
-    /// before the cursor, and continue until the startd of the database. For new
+    /// before the cursor, and continue until the start of the database. For new
     /// cursors, the iterator will begin with the last item in the database.
     ///
     /// For databases with duplicate data items (`DatabaseFlags::DUP_SORT`), the
@@ -84,8 +84,8 @@ pub trait Cursor<'txn> {
     /// Iterate backwards over database items starting from the end of the database.
     ///
     /// For databases with duplicate data items (`DatabaseFlags::DUP_SORT`), the
-    /// duplicate data items of each key will be returned before moving on to
-    /// the next key.
+    /// duplicate data items of each key will be returned in reverse order before
+    /// moving on to the next key.
     fn iter_end_backwards(&mut self) -> Iter<'txn> {
         Iter::new(self.cursor(), ffi::MDB_LAST, ffi::MDB_PREV)
     }
@@ -115,7 +115,7 @@ pub trait Cursor<'txn> {
 
     /// Iterate backwards over duplicate database items. The iterator will begin with the
     /// item before the cursor, and continue until the start of the database.
-    /// Each item will be returned as an iterator of its duplicates.
+    /// Each item will be returned as an iterator of its duplicates in reverse order.
     fn iter_dup_backwards(&mut self) -> IterDup<'txn> {
         IterDup::new(self.cursor(), ffi::MDB_PREV, Direction::Backwards)
     }
@@ -127,7 +127,8 @@ pub trait Cursor<'txn> {
     }
 
     /// Iterate backwards over duplicate database items starting from the end of the
-    /// database. Each item will be returned as an iterator of its duplicates.
+    /// database. Each item will be returned as an iterator of its duplicates in
+    /// reverse order.
     fn iter_dup_end_backwards(&mut self) -> IterDup<'txn> {
         IterDup::new(self.cursor(), ffi::MDB_LAST, Direction::Backwards)
     }


### PR DESCRIPTION
I implemented backwards iterators which mirror the normal iterators:

`iter` -> `iter_backwarads`
`iter_start` -> `iter_end_backwards`
`iter_dup` -> `iter_dup_backwards`
`iter_dup_start` -> `iter_dup_end_backwards`

I added some tests for those too. I did not implement the remaining routines, because they are not straightforwards to implement, and I don't need them right now:

`iter_from` -> unimplemented
`iter_dup_from` -> unimplemented

These are problematic because LMDB can find a key greater-or-equal, but can't find one less-or-equal. It would have to be emulated by finding greater-or-equal, and stepping backwards if the returned key is greater than the searched key. There would be corner-cases around the first/last elements. An alternative is to have some asymmetric semantics.

It may be best to discuss this separately, since the "easy" backwards iterators cover most use-cases.