### PR TITLE
Update minimal supported version of pkg-config dependency

### DIFF
--- a/lmdb-sys/Cargo.toml
+++ b/lmdb-sys/Cargo.toml
@@ -26,7 +26,7 @@ appveyor = { repository = "mozilla/lmdb-rs" }
 libc = "0.2"
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "0.3.3"
 cc = "1.0"
 bindgen = { version = "0.53.2", default-features = false, optional = true, features = ["runtime"] }
 


### PR DESCRIPTION
I tested our Glean build with `cargo +nightly update -Z minimal-versions` and it broke.
`pkg-config 0.3.0` doesn't compile. The earliest working version seems to be 0.3.3 (and that's still from 2015).
Feel free to bump further.